### PR TITLE
GH-42 find-metadata-dependencies workflow updated

### DIFF
--- a/.github/workflows/metadata-api-find-metadata-dependencies.yml
+++ b/.github/workflows/metadata-api-find-metadata-dependencies.yml
@@ -53,28 +53,15 @@ jobs:
     outputs:
       target_env: ${{ steps.set_env.outputs.env }}
     steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
       - name: Set environment
         id: set_env
         run: |
-          if [ '${{ github.ref }}' = 'refs/heads/dev' ]; then
-            echo 'env=DEV' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/devops/actions' ]; then
-            echo 'env=DEV' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/devops/actions-test' ]; then
-            echo 'env=DEV' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/qa' ]; then
-            echo 'env=QA' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/uat' ]; then
-            echo 'env=UAT' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/preprod' ]; then
-            echo 'env=PREPROD' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/prod' ]; then
-            echo 'env=PROD' >> $GITHUB_OUTPUT
-          elif [ '${{ github.ref }}' = 'refs/heads/main' ]; then
-            echo 'env=PROD' >> $GITHUB_OUTPUT
-          else 
-            echo 'env=DEV' >> $GITHUB_OUTPUT
-          fi
+          chmod +x ./scripts/bash/lib/determine-target-environment.sh
+          TARGET_ENV=$(./scripts/bash/lib/determine-target-environment.sh '${{ github.ref }}')
+          echo "env=$TARGET_ENV" >> $GITHUB_OUTPUT
 
   find-dependencies:
     needs: set-target-env

--- a/scripts/bash/lib/determine-target-environment.sh
+++ b/scripts/bash/lib/determine-target-environment.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# -----------------------------------------------------------------------------
+# @file scripts/bash/environments/determine-target-environment.sh
+# @brief Determines the target environment based on Git branch reference.
+#
+# @description
+#   This script maps Git branch references to their corresponding deployment
+#   environments. It outputs the environment name that can be used in GitHub
+#   Actions workflows or other automation scripts.
+#
+# @usage
+#   ./determine-target-environment.sh [BRANCH_REF]
+#   
+#   If no BRANCH_REF is provided, it will use the GITHUB_REF environment variable.
+#
+# @parameters
+#   BRANCH_REF: Git branch reference (e.g., refs/heads/dev, refs/heads/main)
+#
+# @outputs
+#   Environment name (DEV, QA, UAT, PREPROD, PROD)
+#
+# @examples
+#   ./determine-target-environment.sh "refs/heads/dev"     # Outputs: DEV
+#   ./determine-target-environment.sh "refs/heads/main"    # Outputs: PROD
+#   GITHUB_REF="refs/heads/qa" ./determine-target-environment.sh  # Outputs: QA
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+# Get the branch reference from parameter or environment variable
+BRANCH_REF="${1:-${GITHUB_REF:-}}"
+
+# Validate that we have a branch reference
+if [[ -z "$BRANCH_REF" ]]; then
+    echo "Error: No branch reference provided. Use parameter or set GITHUB_REF environment variable." >&2
+    exit 1
+fi
+
+# Determine environment based on branch reference
+case "$BRANCH_REF" in
+    "refs/heads/dev" | "refs/heads/devops/actions" | "refs/heads/devops/actions-test")
+        echo "DEV"
+        ;;
+    "refs/heads/qa")
+        echo "QA"
+        ;;
+    "refs/heads/uat")
+        echo "UAT"
+        ;;
+    "refs/heads/preprod")
+        echo "PREPROD"
+        ;;
+    "refs/heads/prod" | "refs/heads/main")
+        echo "PROD"
+        ;;
+    *)
+        # Default to DEV for any other branch
+        echo "DEV"
+        ;;
+esac


### PR DESCRIPTION
This pull request refactors the process of determining deployment environments in a GitHub Actions workflow by introducing a reusable Bash script. The changes improve maintainability and reduce redundancy by centralizing environment mapping logic into a single script.

### Workflow refactoring:

* [`.github/workflows/metadata-api-find-metadata-dependencies.yml`](diffhunk://#diff-20546e3fc536f976380ea763d6734f3b30ed14080cc7da6300cbec677e5eab24R56-R64): Replaced inline environment mapping logic with a call to the new `determine-target-environment.sh` script, simplifying the workflow file and ensuring consistent environment determination.

### Script addition:

* [`scripts/bash/lib/determine-target-environment.sh`](diffhunk://#diff-e490192f3772b66676b11f6995afdb0b726bcdd30b4aaf5022ff59b9d91262a5R1-R60): Added a new Bash script to map Git branch references to deployment environments. This script centralizes the logic, supports parameterized and environment-variable-based inputs, and provides clear documentation for usage and examples.

Resolves GH-42