### PR TITLE
GH-48 Find metadata dependencies summary display unknown

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "description": "Repository to store GitHub actions and automation scripts to work with salesforce instances.",
+  "type": "module",
   "scripts": {
     "lint": "eslint **/{aura,lwc}/**/*.js",
     "test": "npm run test:unit",

--- a/scripts/find-metadata-dependencies/js/summary.js
+++ b/scripts/find-metadata-dependencies/js/summary.js
@@ -59,9 +59,9 @@ export const buildSourceComponentTable = (record) => {
 			{ data: 'Name', header: true }
 		],
 		[
-			{ data: record.RefMetadataComponentId || 'Unknown' },
-			{ data: record.RefMetadataComponentType || 'Unknown' },
-			{ data: record.RefMetadataComponentName || 'Unknown' }
+			{ data: record.RefMetadataComponentId || '-' },
+			{ data: record.RefMetadataComponentType || '-' },
+			{ data: record.RefMetadataComponentName || '-' }
 		]
 	];
 };


### PR DESCRIPTION
This pull request introduces two main changes: the addition of module type support in the `package.json` file and an update to the default values in a table-building function in `summary.js`.

Configuration update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6): Added `"type": "module"` to enable ES module support for the project.

Code enhancement:

* [`scripts/find-metadata-dependencies/js/summary.js`](diffhunk://#diff-479f7136d8a29611063c88657ca2d218e084598ff4c042eab94e6ddd57c96004L62-R64): Updated the default values in the `buildSourceComponentTable` function to use `'-'` instead of `'Unknown'` for missing data, improving clarity and consistency.

Resolves GH-48 