### PR TITLE
GH-57: Removing username from config/scratch-orgs/dev-def.json

### DIFF
--- a/config/scratch-orgs/dev-def.json
+++ b/config/scratch-orgs/dev-def.json
@@ -1,7 +1,6 @@
 {
 	"orgName": "dev",
 	"edition": "Developer",
-	"username": "alberto.mata@metasintaxis-scratch-01.dev",
 	"adminEmail": "alberto.mata@metasintaxis.com",
 	"description": "Scratch org for development purposes",
 	"features": ["EnableSetPasswordInApi"],


### PR DESCRIPTION
This pull request includes a small change to the `config/scratch-orgs/dev-def.json` file. The change removes the `username` field from the configuration, simplifying the scratch org definition.

Resolves GH-57