### PR TITLE
GH-72: Add Support to Create Branches Based on a Specific GitHub issue

### DIFF
--- a/scripts/issue-management/bash/create-branches.sh
+++ b/scripts/issue-management/bash/create-branches.sh
@@ -9,15 +9,19 @@
 #   Git branches from a base branch (default: dev). Issues with specified exclude labels
 #   can be filtered out. Each branch follows the naming convention:
 #   GH-[ISSUE_NUMBER]-Issue-Title. The script uses the fetch-issues.sh script as a dependency.
+#   You can either process all open issues or create a branch for a specific issue number.
 #
 # @usage
 #   ./create-branches.sh -r <repo> [--base-branch <branch>] [--exclude-labels <labels>] [--dry-run] [--json] [--log FILE] [--debug [LEVEL]]
+#   ./create-branches.sh -r <repo> --issue <number> [--base-branch <branch>] [--dry-run] [--json] [--log FILE] [--debug [LEVEL]]
 #   ./create-branches.sh -r owner/repo-name [--exclude-labels "help wanted,wontfix"] [--json] [--log FILE] [--debug [LEVEL]]
 #
 # @options
 #   -r, --repo REPO       GitHub repository in format owner/repo-name (required).
+#   -i, --issue NUMBER    Create branch for specific issue number only.
 #   --base-branch BRANCH  Base branch to create new branches from (default: dev).
 #   --exclude-labels LABELS  Comma-separated list of labels to exclude (default: "help wanted,wontfix").
+#                         Ignored when --issue is specified.
 #   --dry-run             Show what branches would be created without actually creating them.
 #   --json                Output result and errors in JSON format.
 #   --log FILE            Write debug and operational logs to specified file
@@ -40,6 +44,7 @@ source "${SCRIPT_DIR}/../../bash/lib/logging/watts/logging.sh"
 
 # Default values for arguments
 REPO=""
+ISSUE_NUMBER=""
 BASE_BRANCH="dev"
 EXCLUDE_LABELS="help wanted,wontfix"
 DRY_RUN=false
@@ -53,11 +58,14 @@ FETCH_ISSUES_SCRIPT="${SCRIPT_DIR}/fetch-issues.sh"
 show_usage() {
 	echo "Usage:"
 	echo "  $0 -r <repo> [--base-branch <branch>] [--exclude-labels <labels>] [--dry-run] [--json] [--log FILE] [--debug [LEVEL]]"
+	echo "  $0 -r <repo> --issue <number> [--base-branch <branch>] [--dry-run] [--json] [--log FILE] [--debug [LEVEL]]"
 	echo
 	echo "Options:"
 	echo "  -r, --repo REPO         GitHub repository in format owner/repo-name (required)."
+	echo "  -i, --issue NUMBER      Create branch for specific issue number only."
 	echo "  --base-branch BRANCH    Base branch to create new branches from (default: dev)."
 	echo "  --exclude-labels LABELS Comma-separated list of labels to exclude (default: \"help wanted,wontfix\")."
+	echo "                          Ignored when --issue is specified."
 	echo "  --dry-run               Show what branches would be created without actually creating them."
 	echo "  --json                  Output result and errors in JSON format."
 	echo "  --log FILE              Write debug and operational logs to specified file"
@@ -68,18 +76,23 @@ show_usage() {
 	echo
 	echo "Description:"
 	echo "  This script fetches open issues from the specified GitHub repository"
-	echo "  (excluding those with specified exclude labels) and creates"
-	echo "  corresponding Git branches with the format:"
+	echo "  and creates corresponding Git branches with the format:"
 	echo "  GH-[ISSUE_NUMBER]-Issue-Title"
+	echo
+	echo "  When --issue is specified, only that specific issue will be processed,"
+	echo "  regardless of its labels. When not specified, all open issues are"
+	echo "  processed (excluding those with specified exclude labels)."
 	echo
 	echo "Examples:"
 	echo "  $0 -r metasintaxis/sf-actions-dev"
 	echo "  $0 -r owner/repo --base-branch main --exclude-labels \"wontfix,duplicate\" --dry-run"
+	echo "  $0 -r owner/repo --issue 42 --base-branch main --dry-run"
 	echo "  $0 -r owner/repo --exclude-labels \"\" --json --debug INFO  # No exclusions"
 }
 
 parse_args() {
 	REPO=""
+	ISSUE_NUMBER=""
 	BASE_BRANCH="dev"
 	EXCLUDE_LABELS="help wanted,wontfix"
 	DRY_RUN=false
@@ -91,6 +104,10 @@ parse_args() {
 		case "$1" in
 			-r | --repo)
 				REPO="$2"
+				shift 2
+				;;
+			-i | --issue)
+				ISSUE_NUMBER="$2"
 				shift 2
 				;;
 			--base-branch)
@@ -239,6 +256,22 @@ validate_args() {
 			print_error_block "$msg" "$detail" "INVALID_FORMAT" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
 		fi
 		exit 1
+	fi
+
+	# Validate issue number if provided
+	if [ -n "$ISSUE_NUMBER" ]; then
+		if [[ ! "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+			log_error_stderr "Invalid issue number: $ISSUE_NUMBER"
+			local msg="Error: issue number must be a positive integer"
+			local detail="Issue number provided: '$ISSUE_NUMBER'"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "INVALID_ISSUE_NUMBER" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "INVALID_ISSUE_NUMBER" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
 	fi
 
 	# Validate base branch name (basic validation)
@@ -430,9 +463,51 @@ create_branch_for_issue() {
 	fi
 }
 
+# Function to fetch a specific issue
+fetch_specific_issue() {
+	local issue_number="$1"
+	log_debug_stderr "Fetching specific issue #$issue_number from $REPO"
+
+	local fetch_args=(
+		"-r" "$REPO"
+		"--issue" "$issue_number"
+		"--json"
+	)
+
+	# Add debug flag if present
+	if [ -n "$DEBUG_LEVEL" ]; then
+		fetch_args+=("--debug" "$DEBUG_LEVEL")
+	fi
+
+	# Add log file if present
+	if [ -n "$LOG_FILE" ]; then
+		fetch_args+=("--log" "$LOG_FILE")
+	fi
+
+	local issue_response
+	if ! issue_response=$("$FETCH_ISSUES_SCRIPT" "${fetch_args[@]}"); then
+		log_error_stderr "Failed to fetch issue #$issue_number"
+		return 1
+	fi
+
+	# Extract the issue data from the response
+	local issue_json
+	if ! issue_json=$(echo "$issue_response" | jq -r '.detail' 2> /dev/null); then
+		log_error_stderr "Failed to parse issue response"
+		return 1
+	fi
+
+	echo "$issue_json"
+}
+
 create-branches() {
-	log_info_stderr "Creating branches from open issues"
-	log_debug_stderr "Repository: $REPO, Base branch: $BASE_BRANCH, Exclude labels: '$EXCLUDE_LABELS', Dry run: $DRY_RUN"
+	if [ -n "$ISSUE_NUMBER" ]; then
+		log_info_stderr "Creating branch for specific issue #$ISSUE_NUMBER"
+		log_debug_stderr "Repository: $REPO, Issue: $ISSUE_NUMBER, Base branch: $BASE_BRANCH, Dry run: $DRY_RUN"
+	else
+		log_info_stderr "Creating branches from open issues"
+		log_debug_stderr "Repository: $REPO, Base branch: $BASE_BRANCH, Exclude labels: '$EXCLUDE_LABELS', Dry run: $DRY_RUN"
+	fi
 
 	# Check if base branch exists
 	if ! check_base_branch; then
@@ -447,96 +522,117 @@ create-branches() {
 		exit 1
 	fi
 
-	# Fetch open issues using the fetch-issues script
-	log_debug_stderr "Fetching open issues from $REPO"
-	local fetch_args=(
-		"-r" "$REPO"
-		"--state" "open"
-		"--json"
-	)
-
-	# Add debug flag if present
-	if [ -n "$DEBUG_LEVEL" ]; then
-		fetch_args+=("--debug" "$DEBUG_LEVEL")
-	fi
-
-	# Add log file if present
-	if [ -n "$LOG_FILE" ]; then
-		fetch_args+=("--log" "$LOG_FILE")
-	fi
-
-	local issues_response
-	if ! issues_response=$("$FETCH_ISSUES_SCRIPT" "${fetch_args[@]}"); then
-		log_error_stderr "Failed to fetch issues"
-		local msg="Error: Failed to fetch open issues"
-		local detail="The fetch-issues script failed to retrieve issues from $REPO"
-		local func="${FUNCNAME[0]}"
-		if [ "$JSON_OUTPUT" = true ]; then
-			print_error_json "$msg" "$detail" "FETCH_FAILED" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		else
-			print_error_block "$msg" "$detail" "FETCH_FAILED" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		fi
-		exit 1
-	fi
-
-	# Extract the issues array from the response
-	local all_issues_json
-	if ! all_issues_json=$(echo "$issues_response" | jq -r '.detail' 2> /dev/null); then
-		log_error_stderr "Failed to parse issues response"
-		local msg="Error: Invalid response format from fetch-issues script"
-		local detail="Could not extract issues data from the response"
-		local func="${FUNCNAME[0]}"
-		if [ "$JSON_OUTPUT" = true ]; then
-			print_error_json "$msg" "$detail" "PARSE_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		else
-			print_error_block "$msg" "$detail" "PARSE_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		fi
-		exit 1
-	fi
-
-	# Filter out issues with excluded labels
-	log_debug_stderr "Filtering out issues with excluded labels: '$EXCLUDE_LABELS'"
 	local issues_json
-	local filter_expression
-	filter_expression=$(build_exclude_filter "$EXCLUDE_LABELS")
-
-	if ! issues_json=$(echo "$all_issues_json" | jq "$filter_expression" 2> /dev/null); then
-		log_error_stderr "Failed to filter issues"
-		local msg="Error: Failed to filter issues by labels"
-		local detail="Could not filter out issues with excluded labels: '$EXCLUDE_LABELS'"
-		local func="${FUNCNAME[0]}"
-		if [ "$JSON_OUTPUT" = true ]; then
-			print_error_json "$msg" "$detail" "FILTER_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		else
-			print_error_block "$msg" "$detail" "FILTER_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		fi
-		exit 1
-	fi
-
-	# Count total issues after filtering
 	local total_all_issues
 	local total_issues
-	if ! total_all_issues=$(echo "$all_issues_json" | jq length 2> /dev/null) || ! total_issues=$(echo "$issues_json" | jq length 2> /dev/null); then
-		log_error_stderr "Failed to count issues"
-		local msg="Error: Could not count issues"
-		local detail="Issues data is not in expected array format"
-		local func="${FUNCNAME[0]}"
-		if [ "$JSON_OUTPUT" = true ]; then
-			print_error_json "$msg" "$detail" "COUNT_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		else
-			print_error_block "$msg" "$detail" "COUNT_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
-		fi
-		exit 1
-	fi
 
-	local filtered_count=$((total_all_issues - total_issues))
-	log_info_stderr "Found $total_all_issues open issues, filtered out $filtered_count with excluded labels"
-	log_info_stderr "Processing $total_issues eligible issues"
+	if [ -n "$ISSUE_NUMBER" ]; then
+		# Fetch specific issue
+		if ! issues_json=$(fetch_specific_issue "$ISSUE_NUMBER"); then
+			local msg="Error: Failed to fetch issue #$ISSUE_NUMBER"
+			local detail="The issue may not exist or may not be accessible"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "ISSUE_NOT_FOUND" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "ISSUE_NOT_FOUND" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		# Wrap single issue in array for consistent processing
+		issues_json="[$issues_json]"
+		total_all_issues=1
+		total_issues=1
+	else
+		# Fetch open issues using the fetch-issues script
+		log_debug_stderr "Fetching open issues from $REPO"
+		local fetch_args=(
+			"-r" "$REPO"
+			"--state" "open"
+			"--json"
+		)
+
+		# Add debug flag if present
+		if [ -n "$DEBUG_LEVEL" ]; then
+			fetch_args+=("--debug" "$DEBUG_LEVEL")
+		fi
+
+		# Add log file if present
+		if [ -n "$LOG_FILE" ]; then
+			fetch_args+=("--log" "$LOG_FILE")
+		fi
+
+		local issues_response
+		if ! issues_response=$("$FETCH_ISSUES_SCRIPT" "${fetch_args[@]}"); then
+			log_error_stderr "Failed to fetch issues"
+			local msg="Error: Failed to fetch open issues"
+			local detail="The fetch-issues script failed to retrieve issues from $REPO"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "FETCH_FAILED" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "FETCH_FAILED" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		# Extract the issues array from the response
+		local all_issues_json
+		if ! all_issues_json=$(echo "$issues_response" | jq -r '.detail' 2> /dev/null); then
+			log_error_stderr "Failed to parse issues response"
+			local msg="Error: Invalid response format from fetch-issues script"
+			local detail="Could not extract issues data from the response"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "PARSE_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "PARSE_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		# Filter out issues with excluded labels
+		log_debug_stderr "Filtering out issues with excluded labels: '$EXCLUDE_LABELS'"
+		local filter_expression
+		filter_expression=$(build_exclude_filter "$EXCLUDE_LABELS")
+
+		if ! issues_json=$(echo "$all_issues_json" | jq "$filter_expression" 2> /dev/null); then
+			log_error_stderr "Failed to filter issues"
+			local msg="Error: Failed to filter issues by labels"
+			local detail="Could not filter out issues with excluded labels: '$EXCLUDE_LABELS'"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "FILTER_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "FILTER_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		# Count total issues after filtering
+		if ! total_all_issues=$(echo "$all_issues_json" | jq length 2> /dev/null) || ! total_issues=$(echo "$issues_json" | jq length 2> /dev/null); then
+			log_error_stderr "Failed to count issues"
+			local msg="Error: Could not count issues"
+			local detail="Issues data is not in expected array format"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "COUNT_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "COUNT_ERROR" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		local filtered_count=$((total_all_issues - total_issues))
+		log_info_stderr "Found $total_all_issues open issues, filtered out $filtered_count with excluded labels"
+		log_info_stderr "Processing $total_issues eligible issues"
+	fi
 
 	if [ "$total_issues" -eq 0 ]; then
 		local msg="No eligible issues found"
 		local excluded_labels_msg=""
-		if [ -n "$EXCLUDE_LABELS" ]; then
+		if [ -z "$ISSUE_NUMBER" ] && [ -n "$EXCLUDE_LABELS" ]; then
 			excluded_labels_msg=" after filtering out issues with labels: '$EXCLUDE_LABELS'"
 		fi
 		local detail="No open issues found in repository $REPO$excluded_labels_msg"
@@ -581,7 +677,7 @@ create-branches() {
 
 	# Prepare exclude labels array for JSON
 	local exclude_labels_array="[]"
-	if [ -n "$EXCLUDE_LABELS" ]; then
+	if [ -z "$ISSUE_NUMBER" ] && [ -n "$EXCLUDE_LABELS" ]; then
 		local IFS=','
 		read -ra labels_array <<< "$EXCLUDE_LABELS"
 		local cleaned_labels=()
@@ -598,49 +694,89 @@ create-branches() {
 	fi
 
 	local summary_json
-	summary_json=$(jq -n \
-		--argjson total_all "$total_all_issues" \
-		--argjson total_eligible "$total_issues" \
-		--argjson filtered_out "$filtered_count" \
-		--argjson created "$created_count" \
-		--argjson skipped "$skipped_count" \
-		--argjson failed "$failed_count" \
-		--argjson created_branches "$(printf '%s\n' "${created_branches[@]}" | jq -R . | jq -s .)" \
-		--argjson skipped_branches "$(printf '%s\n' "${skipped_branches[@]}" | jq -R . | jq -s .)" \
-		--argjson failed_branches "$(printf '%s\n' "${failed_branches[@]}" | jq -R . | jq -s .)" \
-		--arg repo "$REPO" \
-		--arg base_branch "$BASE_BRANCH" \
-		--argjson exclude_labels "$exclude_labels_array" \
-		--argjson dry_run "$DRY_RUN" \
-		'{
-			repository: $repo,
-			base_branch: $base_branch,
-			dry_run: $dry_run,
-			filtering: {
-				total_open_issues: $total_all,
-				filtered_out_count: $filtered_out,
-				eligible_issues: $total_eligible,
-				excluded_labels: $exclude_labels
-			},
-			summary: {
-				total_issues: $total_eligible,
-				created_branches: $created,
-				skipped_branches: $skipped,
-				failed_branches: $failed
-			},
-			branches: {
-				created: $created_branches,
-				skipped: $skipped_branches,
-				failed: $failed_branches
-			}
-		}')
+	if [ -n "$ISSUE_NUMBER" ]; then
+		# Summary for specific issue
+		summary_json=$(jq -n \
+			--argjson created "$created_count" \
+			--argjson skipped "$skipped_count" \
+			--argjson failed "$failed_count" \
+			--argjson created_branches "$(printf '%s\n' "${created_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson skipped_branches "$(printf '%s\n' "${skipped_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson failed_branches "$(printf '%s\n' "${failed_branches[@]}" | jq -R . | jq -s .)" \
+			--arg repo "$REPO" \
+			--argjson issue_number "$ISSUE_NUMBER" \
+			--arg base_branch "$BASE_BRANCH" \
+			--argjson dry_run "$DRY_RUN" \
+			'{
+                repository: $repo,
+                issue_number: $issue_number,
+                base_branch: $base_branch,
+                dry_run: $dry_run,
+                summary: {
+                    created_branches: $created,
+                    skipped_branches: $skipped,
+                    failed_branches: $failed
+                },
+                branches: {
+                    created: $created_branches,
+                    skipped: $skipped_branches,
+                    failed: $failed_branches
+                }
+            }')
+	else
+		# Summary for all issues
+		summary_json=$(jq -n \
+			--argjson total_all "$total_all_issues" \
+			--argjson total_eligible "$total_issues" \
+			--argjson filtered_out "$((total_all_issues - total_issues))" \
+			--argjson created "$created_count" \
+			--argjson skipped "$skipped_count" \
+			--argjson failed "$failed_count" \
+			--argjson created_branches "$(printf '%s\n' "${created_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson skipped_branches "$(printf '%s\n' "${skipped_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson failed_branches "$(printf '%s\n' "${failed_branches[@]}" | jq -R . | jq -s .)" \
+			--arg repo "$REPO" \
+			--arg base_branch "$BASE_BRANCH" \
+			--argjson exclude_labels "$exclude_labels_array" \
+			--argjson dry_run "$DRY_RUN" \
+			'{
+                repository: $repo,
+                base_branch: $base_branch,
+                dry_run: $dry_run,
+                filtering: {
+                    total_open_issues: $total_all,
+                    filtered_out_count: $filtered_out,
+                    eligible_issues: $total_eligible,
+                    excluded_labels: $exclude_labels
+                },
+                summary: {
+                    total_issues: $total_eligible,
+                    created_branches: $created,
+                    skipped_branches: $skipped,
+                    failed_branches: $failed
+                },
+                branches: {
+                    created: $created_branches,
+                    skipped: $skipped_branches,
+                    failed: $failed_branches
+                }
+            }')
+	fi
 
 	local success_status="OK"
 	local message
-	if [ "$DRY_RUN" = true ]; then
-		message="Dry run completed: would create $created_count branches from $total_issues eligible issues (filtered from $total_all_issues total)"
+	if [ -n "$ISSUE_NUMBER" ]; then
+		if [ "$DRY_RUN" = true ]; then
+			message="Dry run completed: would create branch for issue #$ISSUE_NUMBER"
+		else
+			message="Successfully processed issue #$ISSUE_NUMBER: created $created_count branches, skipped $skipped_count existing, failed $failed_count"
+		fi
 	else
-		message="Successfully processed $total_issues eligible issues: created $created_count branches, skipped $skipped_count existing, failed $failed_count"
+		if [ "$DRY_RUN" = true ]; then
+			message="Dry run completed: would create $created_count branches from $total_issues eligible issues (filtered from $total_all_issues total)"
+		else
+			message="Successfully processed $total_issues eligible issues: created $created_count branches, skipped $skipped_count existing, failed $failed_count"
+		fi
 	fi
 
 	log_debug_stderr "Preparing output in requested format"
@@ -668,7 +804,7 @@ main() {
 	init_script_logging "$DEBUG_LEVEL" "$LOG_FILE"
 
 	log_debug_stderr "Starting script with arguments: $*"
-	log_info_stderr "Parsed arguments - Repo: '$REPO', Base branch: '$BASE_BRANCH', Exclude labels: '$EXCLUDE_LABELS', Dry run: $DRY_RUN, JSON output: $JSON_OUTPUT, Debug level: ${DEBUG_LEVEL:-NONE}, Log file: ${LOG_FILE:-NONE}"
+	log_info_stderr "Parsed arguments - Repo: '$REPO', Issue: '${ISSUE_NUMBER:-ALL}', Base branch: '$BASE_BRANCH', Exclude labels: '$EXCLUDE_LABELS', Dry run: $DRY_RUN, JSON output: $JSON_OUTPUT, Debug level: ${DEBUG_LEVEL:-NONE}, Log file: ${LOG_FILE:-NONE}"
 
 	validate_args
 	log_debug_stderr "Argument validation completed successfully"

--- a/scripts/issue-management/bash/fetch-issues.sh
+++ b/scripts/issue-management/bash/fetch-issues.sh
@@ -12,15 +12,17 @@
 #
 # @usage
 #   ./fetch-active-issues.sh -r <repo> [--state <state>] [--assignee <user>] [--labels <labels>] [--exclude-labels <labels>] [--limit <num>] [--json] [--log FILE] [--debug [LEVEL]]
+#   ./fetch-active-issues.sh -r <repo> --issue <number> [--json] [--log FILE] [--debug [LEVEL]]
 #   ./fetch-active-issues.sh -r owner/repo-name [--json] [--log FILE] [--debug [LEVEL]]
 #
 # @options
 #   -r, --repo REPO       GitHub repository in format owner/repo-name (required).
-#   --state STATE         Issue state: open, closed, all (default: open).
-#   --assignee USER       Filter by assignee username.
-#   --labels LABELS       Filter by labels (comma-separated).
-#   --exclude-labels LABELS  Exclude issues with any of these labels (comma-separated).
-#   --limit NUM           Maximum number of issues to fetch (default: 30).
+#   -i, --issue NUMBER    Fetch specific issue by number.
+#   --state STATE         Issue state: open, closed, all (default: open). Ignored when --issue is specified.
+#   --assignee USER       Filter by assignee username. Ignored when --issue is specified.
+#   --labels LABELS       Filter by labels (comma-separated). Ignored when --issue is specified.
+#   --exclude-labels LABELS  Exclude issues with any of these labels (comma-separated). Ignored when --issue is specified.
+#   --limit NUM           Maximum number of issues to fetch (default: 30). Ignored when --issue is specified.
 #   --json                Output result and errors in JSON format.
 #   --log FILE            Write debug and operational logs to specified file
 #   --debug [LEVEL]       Enable debug logging to stderr. Optional LEVEL:
@@ -42,6 +44,7 @@ source "${SCRIPT_DIR}/../../bash/lib/logging/watts/logging.sh"
 
 # Default values for arguments
 REPO=""
+ISSUE_NUMBER=""
 STATE="open"
 ASSIGNEE=""
 LABELS=""
@@ -54,14 +57,16 @@ LOG_FILE=""
 show_usage() {
 	echo "Usage:"
 	echo "  $0 -r <repo> [--state <state>] [--assignee <user>] [--labels <labels>] [--exclude-labels <labels>] [--limit <num>] [--json] [--log FILE] [--debug [LEVEL]]"
+	echo "  $0 -r <repo> --issue <number> [--json] [--log FILE] [--debug [LEVEL]]"
 	echo
 	echo "Options:"
 	echo "  -r, --repo REPO       GitHub repository in format owner/repo-name (required)."
-	echo "  --state STATE         Issue state: open, closed, all (default: open)."
-	echo "  --assignee USER       Filter by assignee username."
-	echo "  --labels LABELS       Filter by labels (comma-separated)."
-	echo "  --exclude-labels LABELS  Exclude issues with any of these labels (comma-separated)."
-	echo "  --limit NUM           Maximum number of issues to fetch (default: 30)."
+	echo "  -i, --issue NUMBER    Fetch specific issue by number."
+	echo "  --state STATE         Issue state: open, closed, all (default: open). Ignored when --issue is specified."
+	echo "  --assignee USER       Filter by assignee username. Ignored when --issue is specified."
+	echo "  --labels LABELS       Filter by labels (comma-separated). Ignored when --issue is specified."
+	echo "  --exclude-labels LABELS  Exclude issues with any of these labels (comma-separated). Ignored when --issue is specified."
+	echo "  --limit NUM           Maximum number of issues to fetch (default: 30). Ignored when --issue is specified."
 	echo "  --json                Output result and errors in JSON format."
 	echo "  --log FILE            Write debug and operational logs to specified file"
 	echo "  --debug [LEVEL]       Enable debug logging to stderr. Optional LEVEL:"
@@ -69,18 +74,27 @@ show_usage() {
 	echo "                        (default: DEBUG if no level specified)"
 	echo "  -h, --help            Show this help message and exit."
 	echo
+	echo "Description:"
+	echo "  This script fetches issues from the specified GitHub repository."
+	echo "  When --issue is specified, only that specific issue will be fetched,"
+	echo "  and all other filter options (state, assignee, labels, etc.) will be ignored."
+	echo "  When --issue is not specified, all issues matching the specified filters"
+	echo "  will be fetched."
+	echo
 	echo "Examples:"
 	echo "  $0 -r metasintaxis/sf-actions-dev"
 	echo "  $0 -r owner/repo --state all --assignee username --json"
 	echo "  $0 -r owner/repo --labels bug,enhancement --limit 50"
 	echo "  $0 -r owner/repo --exclude-labels 'help wanted,wontfix'"
+	echo "  $0 -r owner/repo --issue 42 --json"
 }
 
 parse_args() {
 	REPO=""
+	ISSUE_NUMBER=""
 	STATE="open"
 	ASSIGNEE=""
-	LABELS="" 
+	LABELS=""
 	EXCLUDE_LABELS=""
 	LIMIT="30"
 	JSON_OUTPUT=false
@@ -91,6 +105,10 @@ parse_args() {
 		case "$1" in
 			-r | --repo)
 				REPO="$2"
+				shift 2
+				;;
+			-i | --issue)
+				ISSUE_NUMBER="$2"
 				shift 2
 				;;
 			--state)
@@ -234,7 +252,25 @@ validate_args() {
 		exit 1
 	fi
 
-	# Validate state
+	# Validate issue number if provided
+	if [ -n "$ISSUE_NUMBER" ]; then
+		if [[ ! "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+			log_error_stderr "Invalid issue number: $ISSUE_NUMBER"
+			local msg="Error: issue number must be a positive integer"
+			local detail="Issue number provided: '$ISSUE_NUMBER'"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "INVALID_ISSUE_NUMBER" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "INVALID_ISSUE_NUMBER" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+		log_debug_stderr "Specific issue mode: will fetch issue #$ISSUE_NUMBER (other filters ignored)"
+		return 0
+	fi
+
+	# Validate state (only when not fetching specific issue)
 	if [[ ! "$STATE" =~ ^(open|closed|all)$ ]]; then
 		log_error_stderr "Invalid state: $STATE"
 		local msg="Error: invalid state specified"
@@ -248,7 +284,7 @@ validate_args() {
 		exit 1
 	fi
 
-	# Validate limit is a positive integer
+	# Validate limit is a positive integer (only when not fetching specific issue)
 	if ! [[ "$LIMIT" =~ ^[1-9][0-9]*$ ]]; then
 		log_error_stderr "Invalid limit: $LIMIT"
 		local msg="Error: limit must be a positive integer"
@@ -328,6 +364,23 @@ init_script_logging() {
 	log_debug_stderr "Logger initialized with level: $effective_level"
 }
 
+# Function to fetch a specific issue by number
+fetch_specific_issue() {
+	local issue_number="$1"
+	log_debug_stderr "Fetching specific issue #$issue_number from $REPO"
+
+	local gh_cmd="gh issue view $issue_number --repo $REPO --json number,title,state,author,createdAt,updatedAt,labels,assignees,url"
+
+	log_debug_stderr "Executing GitHub CLI command: $gh_cmd"
+	local issue_json
+	if ! issue_json=$(eval "$gh_cmd" 2> /dev/null); then
+		log_error_stderr "Failed to fetch issue #$issue_number from GitHub"
+		return 1
+	fi
+
+	echo "$issue_json"
+}
+
 build_gh_command() {
 	log_debug_stderr "Building GitHub CLI command"
 
@@ -352,6 +405,45 @@ build_gh_command() {
 }
 
 fetch-issues() {
+	if [ -n "$ISSUE_NUMBER" ]; then
+		log_info_stderr "Fetching specific issue #$ISSUE_NUMBER from repository: $REPO"
+		log_debug_stderr "Specific issue mode - other filters are ignored"
+
+		# Fetch specific issue
+		local issue_json
+		if ! issue_json=$(fetch_specific_issue "$ISSUE_NUMBER"); then
+			local msg="Error: Failed to fetch issue #$ISSUE_NUMBER"
+			local detail="The issue may not exist or may not be accessible in repository $REPO"
+			local func="${FUNCNAME[0]}"
+			if [ "$JSON_OUTPUT" = true ]; then
+				print_error_json "$msg" "$detail" "ISSUE_NOT_FOUND" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			else
+				print_error_block "$msg" "$detail" "ISSUE_NOT_FOUND" "${LINENO}" "${BASH_SOURCE[0]}" "$func"
+			fi
+			exit 1
+		fi
+
+		log_info_stderr "Successfully fetched issue #$ISSUE_NUMBER"
+
+		# Prepare output
+		local success_status="OK"
+		local message="Successfully fetched issue #$ISSUE_NUMBER from $REPO"
+		local detail="$issue_json"
+
+		log_debug_stderr "Preparing output in requested format"
+		if [ "$JSON_OUTPUT" = true ]; then
+			log_debug_stderr "Outputting structured JSON format"
+			print_standard_json "$success_status" "$message" "$detail"
+		else
+			log_debug_stderr "Outputting human-readable format"
+			print_standard_block "$success_status" "$message" "$detail"
+		fi
+
+		log_info_stderr "Issue fetched successfully"
+		return 0
+	fi
+
+	# Original logic for fetching multiple issues
 	log_info_stderr "Fetching GitHub issues from repository: $REPO"
 	log_debug_stderr "Parameters - State: $STATE, Assignee: ${ASSIGNEE:-none}, Labels: ${LABELS:-none}, Exclude Labels: ${EXCLUDE_LABELS:-none}, Limit: $LIMIT"
 
@@ -378,7 +470,7 @@ fetch-issues() {
 	local issues_json="$all_issues_json"
 	local total_fetched
 	local total_after_filter
-	
+
 	if ! total_fetched=$(echo "$all_issues_json" | jq length 2> /dev/null); then
 		log_error_stderr "Failed to parse GitHub CLI response"
 		local msg="Error: Invalid response from GitHub CLI"
@@ -394,11 +486,11 @@ fetch-issues() {
 
 	if [ -n "$EXCLUDE_LABELS" ]; then
 		log_debug_stderr "Applying exclude labels filter: $EXCLUDE_LABELS"
-		
+
 		# Convert comma-separated exclude labels to jq array format
 		local exclude_labels_array
 		exclude_labels_array=$(echo "$EXCLUDE_LABELS" | sed 's/,/","/g' | sed 's/^/"/' | sed 's/$/"/')
-		
+
 		# Filter out issues that have any of the excluded labels
 		if ! issues_json=$(echo "$all_issues_json" | jq --argjson exclude_labels "[$exclude_labels_array]" '[.[] | select((.labels | map(.name) | any(. as $label | $exclude_labels | index($label))) | not)]' 2> /dev/null); then
 			log_error_stderr "Failed to apply exclude labels filter"
@@ -412,12 +504,12 @@ fetch-issues() {
 			fi
 			exit 1
 		fi
-		
+
 		if ! total_after_filter=$(echo "$issues_json" | jq length 2> /dev/null); then
 			log_error_stderr "Failed to count filtered issues"
 			exit 1
 		fi
-		
+
 		local filtered_count=$((total_fetched - total_after_filter))
 		log_info_stderr "Fetched $total_fetched issues, filtered out $filtered_count with excluded labels, returning $total_after_filter issues"
 	else
@@ -461,7 +553,11 @@ main() {
 	init_script_logging "$DEBUG_LEVEL" "$LOG_FILE"
 
 	log_debug_stderr "Starting script with arguments: $*"
-	log_info_stderr "Parsed arguments - Repo: '$REPO', State: '$STATE', Assignee: '${ASSIGNEE:-none}', Labels: '${LABELS:-none}', Exclude Labels: '${EXCLUDE_LABELS:-none}', Limit: '$LIMIT', JSON output: $JSON_OUTPUT, Debug level: ${DEBUG_LEVEL:-NONE}, Log file: ${LOG_FILE:-NONE}"
+	if [ -n "$ISSUE_NUMBER" ]; then
+		log_info_stderr "Parsed arguments - Repo: '$REPO', Issue: '$ISSUE_NUMBER', JSON output: $JSON_OUTPUT, Debug level: ${DEBUG_LEVEL:-NONE}, Log file: ${LOG_FILE:-NONE}"
+	else
+		log_info_stderr "Parsed arguments - Repo: '$REPO', State: '$STATE', Assignee: '${ASSIGNEE:-none}', Labels: '${LABELS:-none}', Exclude Labels: '${EXCLUDE_LABELS:-none}', Limit: '$LIMIT', JSON output: $JSON_OUTPUT, Debug level: ${DEBUG_LEVEL:-NONE}, Log file: ${LOG_FILE:-NONE}"
+	fi
 
 	validate_args
 	log_debug_stderr "Argument validation completed successfully"


### PR DESCRIPTION
This pull request introduces a new feature to the `create-branches.sh` and `fetch-issues.sh` scripts, enabling the creation of Git branches or fetching data for a specific GitHub issue by its number. It also includes updates to argument validation, usage documentation, and logging to support this functionality.

### Changes to `create-branches.sh`:

**New Feature: Process Specific Issue**
- Added a `--issue` (`-i`) flag to allow creating a branch for a specific issue number. This bypasses label exclusions and other filters. [[1]](diffhunk://#diff-24ce292f5bf3a47340e3ffedf62e91e594674c91c27fb33a752957e748407738R12-R24) [[2]](diffhunk://#diff-24ce292f5bf3a47340e3ffedf62e91e594674c91c27fb33a752957e748407738R109-R112) [[3]](diffhunk://#diff-24ce292f5bf3a47340e3ffedf62e91e594674c91c27fb33a752957e748407738R525-R547)
- Implemented a `fetch_specific_issue` function to retrieve details for a single issue using the `fetch-issues.sh` script.

**Validation and Logging Updates**
- Validates the issue number to ensure it is a positive integer.
- Updated logging to include the issue number in debug and info messages when specified.

**Usage Documentation**
- Updated usage examples and descriptions to reflect the new `--issue` flag. [[1]](diffhunk://#diff-24ce292f5bf3a47340e3ffedf62e91e594674c91c27fb33a752957e748407738R61-R68) [[2]](diffhunk://#diff-24ce292f5bf3a47340e3ffedf62e91e594674c91c27fb33a752957e748407738L71-R95)

### Changes to `fetch-issues.sh`:

**New Feature: Fetch Specific Issue**
- Added a `--issue` (`-i`) flag to fetch details for a specific issue by its number, ignoring other filters such as state, labels, and limits. [[1]](diffhunk://#diff-51ae21560853bcd1095a89537dea5ebe76b1f51ecc75cade8527cddf668d7242R15-R25) [[2]](diffhunk://#diff-51ae21560853bcd1095a89537dea5ebe76b1f51ecc75cade8527cddf668d7242R110-R113)

**Validation and Logging Updates**
- Validates the issue number to ensure it is a positive integer.
- Logs a debug message when fetching a specific issue, indicating that other filters are ignored.

**Usage Documentation**
- Updated usage examples and descriptions to reflect the new `--issue` flag and its behavior.

These changes enhance the flexibility of the scripts, allowing users to target specific issues directly while maintaining backward compatibility with the existing functionality.

Resolves GH-72