### PR TITLE
GH-97: Unbound variables issue for create-branches.sh fixed

### DIFF
--- a/scripts/devops/issue-management/bash/create-branches.sh
+++ b/scripts/devops/issue-management/bash/create-branches.sh
@@ -366,6 +366,23 @@ sanitize_branch_name() {
 		| sed 's/^-\|-$//g'
 }
 
+# Function to convert array to JSON, handling empty arrays properly
+array_to_json() {
+	local array_name="$1"
+	
+	# Get array length using indirect reference
+	local array_length_var="${array_name}[@]"
+	local array_length
+	eval "array_length=\${#${array_name}[@]}"
+	
+	if [ "$array_length" -eq 0 ]; then
+		echo "[]"
+	else
+		# Use eval to expand the array
+		eval "printf '%s\\n' \"\${${array_name}[@]}\"" | jq -R . | jq -s .
+	fi
+}
+
 # Function to build jq filter for excluding labels
 build_exclude_filter() {
 	local exclude_labels="$1"
@@ -700,9 +717,9 @@ create-branches() {
 			--argjson created "$created_count" \
 			--argjson skipped "$skipped_count" \
 			--argjson failed "$failed_count" \
-			--argjson created_branches "$(printf '%s\n' "${created_branches[@]}" | jq -R . | jq -s .)" \
-			--argjson skipped_branches "$(printf '%s\n' "${skipped_branches[@]}" | jq -R . | jq -s .)" \
-			--argjson failed_branches "$(printf '%s\n' "${failed_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson created_branches "$(array_to_json created_branches)" \
+			--argjson skipped_branches "$(array_to_json skipped_branches)" \
+			--argjson failed_branches "$(array_to_json failed_branches)" \
 			--arg repo "$REPO" \
 			--argjson issue_number "$ISSUE_NUMBER" \
 			--arg base_branch "$BASE_BRANCH" \
@@ -732,9 +749,9 @@ create-branches() {
 			--argjson created "$created_count" \
 			--argjson skipped "$skipped_count" \
 			--argjson failed "$failed_count" \
-			--argjson created_branches "$(printf '%s\n' "${created_branches[@]}" | jq -R . | jq -s .)" \
-			--argjson skipped_branches "$(printf '%s\n' "${skipped_branches[@]}" | jq -R . | jq -s .)" \
-			--argjson failed_branches "$(printf '%s\n' "${failed_branches[@]}" | jq -R . | jq -s .)" \
+			--argjson created_branches "$(array_to_json created_branches)" \
+			--argjson skipped_branches "$(array_to_json skipped_branches)" \
+			--argjson failed_branches "$(array_to_json failed_branches)" \
 			--arg repo "$REPO" \
 			--arg base_branch "$BASE_BRANCH" \
 			--argjson exclude_labels "$exclude_labels_array" \


### PR DESCRIPTION
This pull request improves the handling of array-to-JSON conversion in the `create-branches.sh` script, ensuring that empty arrays are correctly represented as empty JSON arrays. The changes enhance reliability when passing branch lists to `jq` for output, preventing malformed JSON in edge cases.

**Array-to-JSON conversion improvements:**

* Added a new `array_to_json` function to convert Bash arrays to JSON, with proper handling for empty arrays to ensure they serialize as `[]`.
* Updated the `create-branches()` function to use `array_to_json` for serializing `created_branches`, `skipped_branches`, and `failed_branches` arrays, replacing the previous inline `jq` pipeline. This change is applied in both summary output blocks. [[1]](diffhunk://#diff-45303d9a136252ed9eb68bb08d718468d86a99a000a665124b33b42b3eeb3906L703-R722) [[2]](diffhunk://#diff-45303d9a136252ed9eb68bb08d718468d86a99a000a665124b33b42b3eeb3906L735-R754)